### PR TITLE
WP_MEMCACHE_DISABLE_FLUSHING logic is reversed

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -336,7 +336,7 @@ class WP_Object_Cache {
 	function flush() {
 
 		// Return true is flushing is disabled
-		if ( ! WP_MEMCACHE_DISABLE_FLUSHING ) {
+		if ( WP_MEMCACHE_DISABLE_FLUSHING ) {
 			return true;
 		}
 


### PR DESCRIPTION
WP_MEMCACHE_DISABLE_FLUSHING implies that true (default) == disabled. However check logic is reversed, and when DISABLE is true it's actually enabled.